### PR TITLE
show a shorter count text if there is only one page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ props:
 * `records` `number` `required` number of records
 * `per-page` `number` `optional` records per page. Default: `25`
 * `chunk` `number` `optional` max pages per chunk. Default: `10`
-* `count-text` `string` `optional` total records text. Default: `Showing {from} to {to} of {count} records`
+* `count-text` `string` `optional` total records text. It can consist of up to 3 parts, divided by `|`.
+  * First part: used when there are multiple pages
+  * Second part: used when there is only one page
+  * Third part: used when there is only one record.
+
+  Default: `Showing {from} to {to} of {count} records|{count} records|One record`
 
 # Handle page selection
 

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -25,7 +25,7 @@ module.exports =
     countText: {
       type: String,
       required: false,
-      default: 'Showing {from} to {to} of {count} records'
+      default: 'Showing {from} to {to} of {count} records|{count} records|One record'
     }
   },
   computed: {
@@ -58,10 +58,12 @@ module.exports =
 
     let from = ((this.page-1) * this.perPage) + 1;
     let to = this.page==(this.totalPages)?this.records:from + this.perPage - 1;
+    let parts = this.countText.split('|');
+    let i = Math.min(this.records==1?2:this.totalPages==1?1:0, parts.length-1);
 
-    return this.countText.replace('{count}', this.records)
-                         .replace('{from}', from)
-                         .replace('{to}', to)
+    return parts[i].replace('{count}', this.records)
+                   .replace('{from}', from)
+                   .replace('{to}', to)
   }
 },
 methods: {


### PR DESCRIPTION
see https://github.com/matfish2/vue-tables-2/issues/14#issuecomment-257134998

The pluralization thing is necessary to avoid _"1 records"_. The format is the same as for [`vue-i18n`](https://kazupon.github.io/vue-i18n/pluralization.html).
