### PR TITLE
Remove bracket on import because error in console

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Simple, generic and non-intrusive pagination component for Vue.js version 2.
 
 import the script:
 
-    import {Pagination} from 'vue-pagination-2';
+    import Pagination from 'vue-pagination-2';
 
 ## Script tag
 


### PR DESCRIPTION
When you import the component no use bracket because when you do it, you have this error in console:

```
[Vue warn]: Unknown custom element: <pagination> - did you register the component correctly? For recursive components, make sure to provide the "name" option.
```