### PR TITLE
Remove "javascript:void(0);" to be compatible with "unsafe-inline" CSP restriction.

### DIFF
--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -332,7 +332,6 @@ props:{
 data: function() {
     return {
         aProps:{
-            href:"javascript:void(0);",
             role:"button"
         }
     }

--- a/src/Pagination.vue
+++ b/src/Pagination.vue
@@ -99,7 +99,6 @@ export default {
   data() {
       return {
           aProps:{
-              href:"javascript:void(0);",
               role:"button"
           }
       }

--- a/src/template.js
+++ b/src/template.js
@@ -12,7 +12,6 @@ module.exports = function() {
       return <li class={`VuePagination__pagination-item ${theme.item} ${this.activeClass(page)}`}
       onClick={this.setPage.bind(this, page)}>
       <a class={`${theme.link} ${this.activeClass(page)}`} 
-      href="javascript:void(0)"
       role="button">{page}</a>
       </li>
       
@@ -23,14 +22,12 @@ module.exports = function() {
       firstPage = <li class={`VuePagination__pagination-item ${theme.item} ${this.page===1?theme.disabled:''} VuePagination__pagination-item-prev-chunk`}
       onClick={this.setPage.bind(this, 1)}>
       <a class={theme.link} 
-      href="javascript:void(0);"
       disabled={this.page===1}>{this.opts.texts.first}</a>
       </li>
       
       lastPage = <li class={`VuePagination__pagination-item ${theme.item} ${this.page===this.totalPages?theme.disabled:''} VuePagination__pagination-item-prev-chunk`}
       onClick={this.setPage.bind(this, this.totalPages)}>
       <a class={theme.link} 
-      href="javascript:void(0);"
       disabled={this.page===this.totalPages}>{this.opts.texts.last}</a>
       </li>
     }
@@ -40,7 +37,6 @@ module.exports = function() {
       prevChunk =  <li class={`VuePagination__pagination-item ${theme.item} ${theme.prev} VuePagination__pagination-item-prev-chunk ${this.allowedChunkClass(-1)}`}
       onClick={this.setChunk.bind(this,-1)}>
       <a class={theme.link} 
-      href="javascript:void(0);"
       disabled={!!this.allowedChunkClass(-1)}>&lt;&lt;</a>
       </li>
       
@@ -48,7 +44,6 @@ module.exports = function() {
       onClick={this.setChunk.bind(this,1)}
       >
       <a class={theme.link} 
-      href="javascript:void(0);"
       disabled={!!this.allowedChunkClass(1)}>&gt;&gt;</a>
       </li>;
       
@@ -63,7 +58,6 @@ module.exports = function() {
     <li class={`VuePagination__pagination-item ${theme.item} ${theme.prev} VuePagination__pagination-item-prev-page ${this.allowedPageClass(this.page-1)}`}
     onClick={this.prev.bind(this)}>
     <a class={theme.link} 
-    href="javascript:void(0);"
     disabled={!!this.allowedPageClass(this.page-1)} 
     >&lt;</a>
     </li>
@@ -71,7 +65,6 @@ module.exports = function() {
     <li class={`VuePagination__pagination-item ${theme.item} ${theme.next} VuePagination__pagination-item-next-page ${this.allowedPageClass(this.page+1)}`}
     onClick={this.next.bind(this)}>
     <a class={theme.link} 
-    href="javascript:void(0);"
     disabled={!!this.allowedPageClass(this.page+1)} 
     >&gt;</a>
     </li>


### PR DESCRIPTION
`<a>` html ements also valid without `href` attribute.

Using `javascript:void(0);` it's a bad practise and braeaks Content Security Policy (CSP).
And removing of `href` prevents default browser behavior (page reload or got another page), so we don't need ugly inline javascript here.

P.S. @matfish2 Update please `vue-tables-2` after this update we need to get rid of CSP erros when user clicks navigation.