### PR TITLE
Fixes #53 (Pagination Items in Template.js has Undefined in the String for its `class`)

### DIFF
--- a/src/RenderlessPagination.js
+++ b/src/RenderlessPagination.js
@@ -78,7 +78,7 @@ export default {
                 page: `${this.itemClass} ${this.Theme.item}`,
                 wrapper: this.Theme.wrapper,
                 count: `VuePagination__count ${this.Theme.count}`,
-                item: This.Theme.item
+                item: this.Theme.item
             },
             hasRecords: this.hasRecords,
             count: this.count,

--- a/src/RenderlessPagination.js
+++ b/src/RenderlessPagination.js
@@ -77,7 +77,8 @@ export default {
                 link: this.Theme.link,
                 page: `${this.itemClass} ${this.Theme.item}`,
                 wrapper: this.Theme.wrapper,
-                count: `VuePagination__count ${this.Theme.count}`
+                count: `VuePagination__count ${this.Theme.count}`,
+                item: This.Theme.item
             },
             hasRecords: this.hasRecords,
             count: this.count,


### PR DESCRIPTION
Fixes #53 by exporting `theme.item` from `RenderlessPagination`. So it can be used in `template.js` for pagination-items